### PR TITLE
Removing explicit set of "Release" to 1

### DIFF
--- a/rpm/index.go
+++ b/rpm/index.go
@@ -102,9 +102,6 @@ func (p *Package) Normalize(arch string, version string) error {
 	p.ChangelogFile = replaceTokens(p.ChangelogFile, tokens)
 	p.ChangelogCmd = replaceTokens(p.ChangelogCmd, tokens)
 
-	if p.Release == "" {
-		p.Release = "1"
-	}
 	if p.Version == "" {
 		p.Version = version
 	}


### PR DESCRIPTION
Resolves #3 by removing "if p.Release == "" {p.Release = "1"} ".  The statement that sets filename checks for empty and handles properly already.