### PR TITLE
Added new field:  AutoReqProv

### DIFF
--- a/rpm/index.go
+++ b/rpm/index.go
@@ -46,6 +46,7 @@ type Package struct {
 	Conflicts     []string          `json:"conflicts,omitempty"`
 	Envs          map[string]string `json:"envs,omitempty"`
 	Menus         []menu            `json:"menus"`
+	AutoReqProv   string            `json:"auto-req-prov",omitempty`
 }
 
 type fileInstruction struct {
@@ -182,6 +183,7 @@ func (p *Package) Normalize(arch string, version string) error {
 	logger.Printf("p.Envs=%s\n", p.Envs)
 	logger.Printf("p.Requires=%s\n", p.Requires)
 	logger.Printf("p.BuildRequires=%s\n", p.BuildRequires)
+	logger.Printf("p.AutoReqProv=%s\n", p.AutoReqProv)
 	return nil
 }
 


### PR DESCRIPTION
Adds support for issue described in #7.

Requires: libc.so.6()(64bit) 
error: Arch dependent binaries in noarch package

This feature is fairly important in RPM packaging, as it is required in order to build "noarch" packages which require other packages which are not "noarch".  For example:  glibc.   Adding "glibc" as a requirement might seem like a straightforward thing to do:  just add the appropriate requires statement to rpm.json.   For example:   "requires" : ["glibc"]. 

This should allow the installing machine to use any version and architecture of glibc to satisfy the dependency.   However, rpmbuild's default behavior effectively "overrides" this by taking the following actions:
-Uses the ldd command to interrogate all files listed under %install 
-Adds all detected "requires" statements to the "requires" section of the spec file before packaging. 

The problem is that rpmbuild detects and adds the architecture-specific identifier for package, based on the architecture of the machine being used to package.  So, either libc.so.6()(64bit) or libc.so.6()(32bit) .  It does not care that you've manually added a less-specific version of the same dependency to the spec file.  This behavior erroneously prevents the package from being created as a "noarch" with error shown above.

The simple solution when using rpmbuild and manually defining the spec file is to simply add AutoReqProv : "no" to the spec file.  go-bin-rpm didn't support this option, so I've added it here.  

References: 
https://wiki.linuxfoundation.org/en/RpmExamples
http://ftp.rpm.org/max-rpm/s1-rpm-depend-auto-depend.html