### PR TITLE
Adding the field 'AutoReqProv' to the generated spec file

### DIFF
--- a/rpm/index.go
+++ b/rpm/index.go
@@ -300,6 +300,9 @@ func (p *Package) GenerateSpecFile(sourceDir string) (string, error) {
 	if p.Summary != "" {
 		spec += fmt.Sprintf("Summary: %s\n", p.Summary)
 	}
+	if p.AutoReqProv != "" {
+		spec += fmt.Sprintf("AutoReqProv: %s\n", p.AutoReqProv)
+	}
 	if len(p.BuildRequires) > 0 {
 		spec += fmt.Sprintf("\nBuildRequires:%s\n", strings.Join(p.BuildRequires, ", "))
 	}


### PR DESCRIPTION
Hello, first of all, thank you for your great work on this project. It helps a lot when creating new RPMs.

I was packing one here, and was facing some issues on the dependency check, which was not important for my case. Checking the PR #8, I've seen that the option to ignore dependencies was added, but it was missing the piece that writes the option to the final spec file, which will be fixed by this PR.


Thank you very much!